### PR TITLE
Avoid race conditions on loading images for reusable cells

### DIFF
--- a/TenElephants/TenElephants/Cache/CachedImageFetcher.swift
+++ b/TenElephants/TenElephants/Cache/CachedImageFetcher.swift
@@ -8,6 +8,12 @@
 import Foundation
 import UIKit
 
+protocol Cancellable {
+    func cancel()
+}
+
+extension URLSessionTask: Cancellable {}
+
 final class CachedImageFetcher {
     private enum Constants {
         static let cacheCountLimit: Int = 25
@@ -24,16 +30,16 @@ final class CachedImageFetcher {
         cachedImages.object(forKey: url)
     }
 
-    func fetch(url: NSURL, completion: @escaping (UIImage?) -> Swift.Void) {
+    func fetch(url: NSURL, completion: @escaping (UIImage?) -> Swift.Void) -> Cancellable? {
         if let cachedImage = image(url: url) {
             DispatchQueue.main.async {
                 completion(cachedImage)
             }
-            return
+            return nil
         }
         if loadingResponses[url] != nil {
             loadingResponses[url]?.append(completion)
-            return
+            return nil
         } else {
             loadingResponses[url] = [completion]
         }
@@ -53,5 +59,6 @@ final class CachedImageFetcher {
             }
         }
         task.resume()
+        return task
     }
 }

--- a/TenElephants/TenElephants/Controllers/TrendPageController.swift
+++ b/TenElephants/TenElephants/Controllers/TrendPageController.swift
@@ -226,19 +226,15 @@ extension TrendPageController: UICollectionViewDataSource {
             cell.isLoading = false
             if viewModelH.meals.isEmpty {
                 cell.isLoading = true
-                cell.titleLabel.text = "Loading..."
-                cell.subtitleLabel.text = ""
+                cell.configure(titleText: "Loading...")
             } else {
                 let item = viewModelH.meals[indexPath.row]
-                cell.titleLabel.text = item.name
-                cell.subtitleLabel.text = item.id
-                guard let link = item.thumbnailLink,
-                      let url = NSURL(string: link) else {
-                    return cell
-                }
-                imageFetcher.fetch(url: url) { image in
-                    cell.imageView.image = image
-                }
+                cell.configure(
+                    titleText: item.name,
+                    subtitleText: item.id,
+                    thumbnailLink: item.thumbnailLink,
+                    imageFetcher: imageFetcher
+                )
             }
             return cell
         case .vertical:
@@ -252,18 +248,16 @@ extension TrendPageController: UICollectionViewDataSource {
 
             if viewModelV.meals.isEmpty {
                 cell.indicator.startAnimating()
+                cell.configure(titleText: nil)
             } else {
                 cell.indicator.stopAnimating()
                 cell.indicator.hidesWhenStopped = true
                 let item = viewModelV.meals[indexPath.row]
-                cell.titleLabel.text = item.name
-                guard let link = item.thumbnailLink,
-                      let url = NSURL(string: link) else {
-                    return cell
-                }
-                imageFetcher.fetch(url: url) { image in
-                    cell.imageView.image = image
-                }
+                cell.configure(
+                    titleText: item.name,
+                    thumbnailLink: item.thumbnailLink,
+                    imageFetcher: imageFetcher
+                )
             }
             return cell
         }

--- a/TenElephants/TenElephants/Views/PreviewCellView.swift
+++ b/TenElephants/TenElephants/Views/PreviewCellView.swift
@@ -9,8 +9,11 @@ import Foundation
 import UIKit
 
 final class PreviewCellView: UICollectionViewCell {
-    lazy var titleLabel = makeTitleLabel()
-    lazy var imageView = makeImageView()
+    private var imageRequest: Cancellable?
+    private var curURL: NSURL?
+
+    lazy var titleLabel    = makeTitleLabel()
+    lazy var imageView     = makeImageView()
     lazy var containerView = makeContainerView()
     lazy var shadowLayer = makeShadowLayer()
     lazy var indicator = makeActivityIndicator()
@@ -107,5 +110,29 @@ extension PreviewCellView {
             y: self.contentView.center.y
         )
         return indicator
+    }
+}
+
+extension PreviewCellView {
+    func configure(
+        titleText: String?,
+        thumbnailLink: String? = nil,
+        imageFetcher: CachedImageFetcher? = nil
+    ) {
+        self.titleLabel.text = titleText
+        guard let link = thumbnailLink,
+              let url = NSURL(string: link) else {
+                  return
+        }
+        guard curURL != url else {
+            return
+        }
+        curURL = url
+        if let imageRequest = imageRequest {
+            imageRequest.cancel()
+        }
+        imageRequest = imageFetcher?.fetch(url: url) { image in
+            self.imageView.image = image
+        }
     }
 }

--- a/TenElephants/TenElephants/Views/WideCellView.swift
+++ b/TenElephants/TenElephants/Views/WideCellView.swift
@@ -8,6 +8,9 @@
 import UIKit
 
 final class WideCellView: UICollectionViewCell {
+    private var imageRequest: Cancellable?
+    private var curURL: NSURL?
+
     private enum Constants {
         static let labelGap: CGFloat = 10
         static let labelHeight: CGFloat = 20
@@ -167,5 +170,31 @@ extension UILabel {
     func stopBlink() {
         layer.removeAllAnimations()
         alpha = 1
+    }
+}
+
+extension WideCellView {
+    func configure(
+        titleText: String?,
+        subtitleText: String = "",
+        thumbnailLink: String? = nil,
+        imageFetcher: CachedImageFetcher? = nil
+    ) {
+        self.titleLabel.text = titleText
+        self.subtitleLabel.text = subtitleText
+        guard let link = thumbnailLink,
+              let url = NSURL(string: link) else {
+                  return
+        }
+        guard curURL != url else {
+            return
+        }
+        curURL = url
+        if let imageRequest = imageRequest {
+            imageRequest.cancel()
+        }
+        imageRequest = imageFetcher?.fetch(url: url) { image in
+            self.imageView.image = image
+        }
     }
 }


### PR DESCRIPTION
When cell gets to be reused, it might have an unfinished image fetching task. Store this task and cancel it in prepareForReuse. Closes #66 